### PR TITLE
Quick update to detect and add support for K3s

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -32,6 +32,9 @@ spec:
         args:
         - "--multus-conf-file=auto"
         - "--cni-version=0.3.1"
+        {{- if contains "k3s" .Capabilities.KubeVersion.GitVersion }}
+        - "--multus-kubeconfig-file-host=/var/lib/rancher/k3s/agent/etc/cni/net.d/multus.d/multus.kubeconfig"
+        {{- end }}
         resources:
           requests:
             cpu: "100m"
@@ -51,10 +54,18 @@ spec:
       volumes:
         - name: cni
           hostPath:
+            {{- if contains "k3s" .Capabilities.KubeVersion.GitVersion }}
+            path: /var/lib/rancher/k3s/agent/etc/cni/net.d
+            {{- else }}
             path: /etc/cni/net.d
+            {{- end }}
         - name: cnibin
           hostPath:
+            {{- if contains "k3s" .Capabilities.KubeVersion.GitVersion }}
+            path: /var/lib/rancher/k3s/data/current/bin
+            {{- else }}
             path: /opt/cni/bin
+            {{- end }}
         - name: multus-cfg
           configMap:
             name: {{ template "multus.name" . }}-config

--- a/values.yaml
+++ b/values.yaml
@@ -41,7 +41,6 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
This commit overrides some of the defaults if we detect a cluster running K3s, taking into consideration its folder hierarchy.